### PR TITLE
Add abstraction for the heuristic and use simple size heuristic

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -46,9 +46,7 @@
 # include <sys/time.h>
 #endif
 
-#ifdef MPTCP_GET_SUB_IDS
-# include <linux/tcp.h>
-#endif
+#include <linux/tcp.h>
 
 #include <netinet/in.h>
 #include <netinet/ip.h>
@@ -2179,6 +2177,11 @@ ssh_packet_disconnect(struct ssh *ssh, const char *fmt,...)
 
 #ifdef MPTCP_GET_SUB_IDS
 
+void
+mptcp_switch_debug(char* content) {
+	debug("[MPTCP] %s", content);
+}
+
 /*
  * Create a new mptcp_switch_heuristic with
  * reset value.
@@ -2192,6 +2195,8 @@ mptcp_switch_heuristic_create(ssize_t reset) {
 	heuristic->reset = reset;
 	heuristic->value = reset;
 
+	mptcp_switch_debug("Creation of a new heuristic");
+
 	return heuristic;
 }
 
@@ -2201,6 +2206,7 @@ mptcp_switch_heuristic_create(ssize_t reset) {
 void
 mptcp_switch_heuristic_reset(struct mptcp_switch_heuristic *heuristic) {
 	heuristic->value = heuristic->reset;
+	mptcp_switch_debug("Reset the heuristic");
 }
 
 /*
@@ -2208,9 +2214,10 @@ mptcp_switch_heuristic_reset(struct mptcp_switch_heuristic *heuristic) {
  */
 int
 mptcp_switch_heuristic_check(struct mptcp_switch_heuristic *heuristic) {
+	mptcp_switch_debug("Check heuristic");
 	if(heuristic->value == 0)
-		return 1;
-	return 0;
+		return 0;
+	return 1;
 }
 
 /*
@@ -2219,6 +2226,7 @@ mptcp_switch_heuristic_check(struct mptcp_switch_heuristic *heuristic) {
 void
 mptcp_switch_heuristic_apply(struct mptcp_switch_heuristic *heuristic, ssize_t new_value) {
 	heuristic->value = new_value;
+	debug("[MPTCP] Apply new value to the heuristic: %zd", new_value);
 }
 
 /*
@@ -2227,13 +2235,14 @@ mptcp_switch_heuristic_apply(struct mptcp_switch_heuristic *heuristic, ssize_t n
 void
 mptcp_switch_heuristic_change(struct mptcp_switch_heuristic *heuristic, ssize_t new_reset) {
 	heuristic->reset = new_reset;
+	mptcp_switch_debug("Change the reset value of the heuristic");
 }
 
 /*
  * Switch the MPTCP subflow if the heuristic is filled.
  */
 void
-mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic heuristic) {
+mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic *heuristic) {
 	if(mptcp_switch_heuristic_check(heuristic))
 		return;
 	
@@ -2249,13 +2258,14 @@ mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic heuristic) {
 	ids = malloc(optlen);
 	if(getsockopt(state->connection_out, IPPROTO_TCP, MPTCP_GET_SUB_IDS, ids, &optlen) == -1) 
 		return;
-	int old_id = ids->subs_status[0].id;
+	int old_id = ids->sub_status[0].id;
 	free(ids);
+	mptcp_switch_debug("Get old subflow");
 
 	// Open new MPTCP subflow
 	struct mptcp_sub_tuple *open_sub;
 	struct sockaddr_in* addr;
-	optlen = sizeof(struct mptcp_sub_tuple) + 2 * sizeof(sockaddr_in);
+	optlen = sizeof(struct mptcp_sub_tuple) + 2 * sizeof(struct sockaddr_in);
 	open_sub = malloc(optlen);
 	open_sub->id = 0;
 
@@ -2269,9 +2279,10 @@ mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic heuristic) {
 	addr->sin_port = htons(ssh->remote_port); 
 	inet_pton(AF_INET, ssh->remote_ipaddr, &addr->sin_addr);
 
-	if(getsockopt(state->connection_out, IPPROTO_TCP, MPTCP_OPEN_SUB_TUPLE, sub_tuple, &optlen) == -1)
+	if(getsockopt(state->connection_out, IPPROTO_TCP, MPTCP_OPEN_SUB_TUPLE, open_sub, &optlen) == -1)
 		return;
 	free(open_sub);
+	mptcp_switch_debug("Create new subflow");
 
 	// Remove old MPTCP subflow
 	struct mptcp_close_sub_id *close_sub;
@@ -2280,6 +2291,8 @@ mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic heuristic) {
 	close_sub->id = old_id;
 	if(getsockopt(state->connection_out, IPPROTO_TCP, MPTCP_CLOSE_SUB_ID, close_sub, &optlen) == -1)
 		return;
+	free(close_sub);
+	mptcp_switch_debug("Remove old subflow");
 }
 
 #endif
@@ -2311,12 +2324,14 @@ ssh_packet_write_poll(struct ssh *ssh)
 	}
 #ifdef MPTCP_GET_SUB_IDS
 	if(heuristic == NULL)
-		mptcp_switch_heuristic_create(MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT);
-	if(len > heuristic->value)
-		mptcp_switch_heuristic_apply(0);
-	else
-		mptcp_switch_heuristic_apply(heuristic->value - len);
-	mptcp_switch_subflow(ssh);
+		heuristic = mptcp_switch_heuristic_create(MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT);
+
+	if(len > heuristic->value) {
+		mptcp_switch_heuristic_apply(heuristic, 0);
+	} else {
+		mptcp_switch_heuristic_apply(heuristic, heuristic->value - len);
+	}
+	mptcp_switch_subflow(ssh, heuristic);
 #endif
 	return 0;
 }

--- a/packet.c
+++ b/packet.c
@@ -2333,7 +2333,6 @@ ssh_packet_write_poll(struct ssh *ssh)
 		heuristics[0] = mptcp_switch_heuristic_create(MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT);
 
 	if(len > heuristics[0]->value) {
-		mptcp_switch_debug("Are whe here ?");
 		mptcp_switch_heuristic_apply(heuristics[0], 0);
 	} else {
 		mptcp_switch_heuristic_apply(heuristics[0], heuristics[0]->value - len);

--- a/packet.c
+++ b/packet.c
@@ -238,7 +238,7 @@ struct mptcp_switch_heuristic {
 #define MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT 100
 #define MPTCP_SWITCH_HEURISTIC_COUNT 1
 
-struct mptcp_switch_heuristic *heuristics[MPTPC_SWITCH_HEURISTIC_COUNT];
+struct mptcp_switch_heuristic *heuristics[MPTCP_SWITCH_HEURISTIC_COUNT];
 
 #endif
 
@@ -2245,7 +2245,7 @@ mptcp_switch_heuristic_change(struct mptcp_switch_heuristic *heuristic, unsigned
 void
 mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic *heuristics[]) {
 	int i;
-	for(i = 0; i < MPTPCP_SWITCH_HEURISTIC_COUNT; i++) {
+	for(i = 0; i < MPTCP_SWITCH_HEURISTIC_COUNT; i++) {
 		if(mptcp_switch_heuristic_check(heuristics[i]))
 			return;
 	}
@@ -2253,7 +2253,7 @@ mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic *heuristics[
 	struct session_state *state = ssh->state;
 
 	// Reset the heuristic size
-	for(i = 0; i < MPTPCP_SWITCH_HEURISTIC_COUNT; i++) {
+	for(i = 0; i < MPTCP_SWITCH_HEURISTIC_COUNT; i++) {
 		mptcp_switch_heuristic_reset(heuristics[i]);
 	}
 
@@ -2329,10 +2329,11 @@ ssh_packet_write_poll(struct ssh *ssh)
 			return r;
 	}
 #ifdef MPTCP_GET_SUB_IDS
-	if(heuristics == NULL)
+	if(heuristics[0] == NULL)
 		heuristics[0] = mptcp_switch_heuristic_create(MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT);
 
 	if(len > heuristics[0]->value) {
+		mptcp_switch_debug("Are whe here ?");
 		mptcp_switch_heuristic_apply(heuristics[0], 0);
 	} else {
 		mptcp_switch_heuristic_apply(heuristics[0], heuristics[0]->value - len);

--- a/packet.c
+++ b/packet.c
@@ -2178,7 +2178,7 @@ ssh_packet_disconnect(struct ssh *ssh, const char *fmt,...)
 
 #ifdef MPTCP_GET_SUB_IDS
 
-void
+static void
 mptcp_switch_debug(char* content) {
 	debug("[MPTCP] %s", content);
 }
@@ -2187,7 +2187,7 @@ mptcp_switch_debug(char* content) {
  * Create a new mptcp_switch_heuristic with
  * reset value.
  */
-struct mptcp_switch_heuristic *
+static struct mptcp_switch_heuristic *
 mptcp_switch_heuristic_create(unsigned int reset) {
 	unsigned int optlen;
 	struct mptcp_switch_heuristic *heuristic;
@@ -2204,7 +2204,7 @@ mptcp_switch_heuristic_create(unsigned int reset) {
 /*
  * Reset the heuristic.
  */
-void
+static void
 mptcp_switch_heuristic_reset(struct mptcp_switch_heuristic *heuristic) {
 	heuristic->value = heuristic->reset;
 	mptcp_switch_debug("Reset the heuristic");
@@ -2213,7 +2213,7 @@ mptcp_switch_heuristic_reset(struct mptcp_switch_heuristic *heuristic) {
 /*
  * Check if the heuristic's condition is filled.
  */
-int
+static int
 mptcp_switch_heuristic_check(struct mptcp_switch_heuristic *heuristic) {
 	mptcp_switch_debug("Check heuristic");
 	if(heuristic->value == 0)
@@ -2224,7 +2224,7 @@ mptcp_switch_heuristic_check(struct mptcp_switch_heuristic *heuristic) {
 /*
  * Apply a new value to the heuristic.
  */
-void
+static void
 mptcp_switch_heuristic_apply(struct mptcp_switch_heuristic *heuristic, unsigned int new_value) {
 	heuristic->value = new_value;
 	mptcp_switch_debug("Change the value of the heuristic");
@@ -2233,7 +2233,7 @@ mptcp_switch_heuristic_apply(struct mptcp_switch_heuristic *heuristic, unsigned 
 /*
  * Apply a new value to the heuristic.
  */
-void
+static void
 mptcp_switch_heuristic_change(struct mptcp_switch_heuristic *heuristic, unsigned int new_reset) {
 	heuristic->reset = new_reset;
 	mptcp_switch_debug("Change the reset value of the heuristic");
@@ -2242,7 +2242,7 @@ mptcp_switch_heuristic_change(struct mptcp_switch_heuristic *heuristic, unsigned
 /*
  * Switch the MPTCP subflow if the heuristic is filled.
  */
-void
+static void
 mptcp_switch_subflow(struct ssh* ssh, struct mptcp_switch_heuristic *heuristics[]) {
 	int i;
 	for(i = 0; i < MPTCP_SWITCH_HEURISTIC_COUNT; i++) {

--- a/packet.h
+++ b/packet.h
@@ -193,6 +193,18 @@ int	sshpkt_get_bignum2(struct ssh *ssh, BIGNUM *v);
 int	sshpkt_get_end(struct ssh *ssh);
 const u_char	*sshpkt_ptr(struct ssh *, size_t *lenp);
 
+/* MPTCP Switch */
+#ifdef MPTCP_SWITCH_GET_IDS
+
+static void	 mptcp_switch_debug(char *);
+static struct mptcp_switch_heuristic	*mptcp_switch_heuristic_create(unsigned int);
+static void	 mptcp_switch_heuristic_reset(struct mptcp_switch_heuristic*);
+static void	 mptcp_switch_heuristic_apply(struct mptcp_switch_heuristic*, unsigned int);
+static void	 mptcp_switch_heuristic_change(struct mptcp_switch_heuristic*, unsigned int);
+static void	 mptcp_switch_subflow(struct ssh*, struct mptcp_switch_heuristic**);
+
+#endif
+
 /* OLD API */
 extern struct ssh *active_state;
 #include "opacket.h"


### PR DESCRIPTION
This is the start point for the MPTCP implementation.

Every functions and variables in connection with the MPTCP implementation start with `mptcp_switch`.

### Abstraction of the heuristic 
* The structure `mptcp_switch_heuristic` is used to represent one heuristic

```c
struct mptcp_switch_heuristic {
    unsigned int value;
    unsigned int reset;
};
```

* When `value` is equal to 0, the heuristic is filled
* `reset` allow us to reset the heuristic

```c
struct mptcp_switch_heuristic *heuristics[MPTCP_SWITCH_HEURISTIC_COUNT];
```

* `heuristics` is an array to store each heuristic (for now only one)

* There are a lot of functions to use, modify, check or reset a heuristic

### MPTCP Switch
The function `mptcp_switch_subflow(struct ssh*, struct mptcp_switch_heuristic**)` is the **main new feature**.

It will first check every heuristics then switch the subflow.

### Important notes

Every part of the source code **must** be put between
```c
#ifdef MPTCP_GET_SUB_IDS
    // Source code
#endif
```