### PR TITLE
Option for user

### DIFF
--- a/packet.c
+++ b/packet.c
@@ -238,11 +238,9 @@ struct mptcp_switch_heuristic {
 };
 
 typedef enum {
-	BYTECOUNT = 0, /* Nombre de byte envoyé avant de changer de flux */
+	BYTECOUNT = 0, /* Number of byte before switching subflow */
 } mptcp_switch_options;
 
-/* TODO Allow to change the reset value with command-lines options. */
-#define MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT 100
 #define MPTCP_SWITCH_HEURISTIC_COUNT 1
 
 struct mptcp_switch_heuristic *heuristics[MPTCP_SWITCH_HEURISTIC_COUNT];

--- a/packet.c
+++ b/packet.c
@@ -87,6 +87,7 @@
 #include "packet.h"
 #include "ssherr.h"
 #include "sshbuf.h"
+#include "readconf.h"
 
 #ifdef PACKET_DEBUG
 #define DBG(x) x
@@ -95,6 +96,9 @@
 #endif
 
 #define PACKET_MAX_SIZE (256 * 1024)
+
+/* Importing options */
+extern Options options;
 
 struct packet_state {
 	u_int32_t seqnr;
@@ -233,6 +237,10 @@ struct mptcp_switch_heuristic {
 	unsigned int value;
 	unsigned int reset;
 };
+
+typedef enum {
+	BYTECOUNT = 0, /* Nombre de byte envoyé avant de changer de flux */
+} mptcp_switch_options;
 
 /* TODO Allow to change the reset value with command-lines options. */
 #define MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT 100
@@ -2341,7 +2349,7 @@ ssh_packet_write_poll(struct ssh *ssh)
 	}
 #ifdef MPTCP_GET_SUB_IDS
 	if(heuristics[0] == NULL)
-		heuristics[0] = mptcp_switch_heuristic_create(MPTCP_SWITCH_HEURISTIC_VALUE_DEFAULT);
+		heuristics[0] = mptcp_switch_heuristic_create(options.nBytes_change);
 
 	if(len > heuristics[0]->value) {
 		mptcp_switch_heuristic_apply(heuristics[0], 0);

--- a/packet.c
+++ b/packet.c
@@ -97,9 +97,6 @@
 
 #define PACKET_MAX_SIZE (256 * 1024)
 
-/* Importing options */
-extern Options options;
-
 struct packet_state {
 	u_int32_t seqnr;
 	u_int32_t packets;
@@ -232,7 +229,11 @@ struct session_state {
 	TAILQ_HEAD(, packet) outgoing;
 };
 
+/* ssh.c */
+extern Options options;
+
 #ifdef MPTCP_GET_SUB_IDS
+
 struct mptcp_switch_heuristic {
 	unsigned int value;
 	unsigned int reset;
@@ -2349,7 +2350,7 @@ ssh_packet_write_poll(struct ssh *ssh)
 	}
 #ifdef MPTCP_GET_SUB_IDS
 	if(heuristics[0] == NULL)
-		heuristics[0] = mptcp_switch_heuristic_create(options.nBytes_change);
+		heuristics[0] = mptcp_switch_heuristic_create(options.mptcp_switch_nBytes);
 
 	if(len > heuristics[0]->value) {
 		mptcp_switch_heuristic_apply(heuristics[0], 0);

--- a/packet.c
+++ b/packet.c
@@ -2206,7 +2206,7 @@ mptcp_switch_debug(char* content)
  * reset value.
  */
 static struct mptcp_switch_heuristic *
-mptcp_switch_heuristic_create(int reset)
+mptcp_switch_heuristic_create(unsigned int reset)
 {
 	struct mptcp_switch_heuristic *heuristic = NULL;
 	if((heuristic = calloc(1,sizeof(*heuristic))) == NULL)
@@ -2237,7 +2237,6 @@ static int
 mptcp_switch_heuristic_check(struct mptcp_switch_heuristic *heuristic)
 {
 	mptcp_switch_debug("Check heuristic");
-	debug("[MPTCP] value of the heuristic : %d\n",heuristic->value);
 	return heuristic->value != 0;
 }
 
@@ -2361,7 +2360,7 @@ ssh_packet_write_poll(struct ssh *ssh)
 	}
 #ifdef MPTCP_GET_SUB_IDS
 	if(heuristics[0] == NULL){
-		if((heuristics[BYTECOUNT] = mptcp_switch_heuristic_create(mptcp_state->mptcp_switch_nBytes)) == NULL){
+		if((heuristics[BYTECOUNT] = mptcp_switch_heuristic_create(mptcp_state->mptcp_switch_nBytes)) == NULL) {
 			mptcp_switch_debug("Can't allocate memory for a new heuristic.");
 			/* TODO handle case where no memory is available via an error message? */
 			return 0;

--- a/packet.h
+++ b/packet.h
@@ -80,10 +80,12 @@ struct ssh {
 	struct mptcp_heuristics *mptcp_state;
 };
 
+#ifdef MPTCP_GET_SUB_IDS
 struct mptcp_heuristics {
 	/* Number of byte before changing of subflow */
 	int mptcp_switch_nBytes;
 };
+#endif
 
 typedef int (ssh_packet_hook_fn)(struct ssh *, struct sshbuf *,
     u_char *, void *);

--- a/packet.h
+++ b/packet.h
@@ -76,6 +76,13 @@ struct ssh {
 
 	/* APP data */
 	void *app_data;
+
+	struct mptcp_heuristics *mptcp_state;
+};
+
+struct mptcp_heuristics {
+	/* Number of byte before changing of subflow */
+	int mptcp_switch_nBytes;
 };
 
 typedef int (ssh_packet_hook_fn)(struct ssh *, struct sshbuf *,
@@ -219,5 +226,4 @@ extern struct ssh *active_state;
 # undef EC_GROUP
 # undef EC_POINT
 #endif
-
 #endif				/* PACKET_H */

--- a/readconf.c
+++ b/readconf.c
@@ -1857,11 +1857,6 @@ initialize_options(Options * options)
 	options->update_hostkeys = -1;
 	options->hostbased_key_types = NULL;
 	options->pubkey_key_types = NULL;
-#ifdef MPTCP_GET_SUB_IDS
-	options->mptcp_switch_want_mptcp = -1;
-	options->mptcp_switch_nBytes = -1;
-	options->mptcp_switch_time = -1;
-#endif
 }
 
 /*
@@ -2074,14 +2069,6 @@ fill_default_options(Options * options)
 	/* options->hostname will be set in the main program if appropriate */
 	/* options->host_key_alias should not be set by default */
 	/* options->preferred_authentications will be set in ssh */
-#ifdef MPTCP_GET_SUB_IDS
-	if(options->mptcp_switch_want_mptcp == -1)
-		options->mptcp_switch_want_mptcp = 1;
-	if(options->mptcp_switch_nBytes == -1)
-		options->mptcp_switch_nBytes = 500;
-	if(options->mptcp_switch_time == -1)
-		options->mptcp_switch_time == 15;
-#endif
 }
 
 struct fwdarg {

--- a/readconf.c
+++ b/readconf.c
@@ -1857,6 +1857,11 @@ initialize_options(Options * options)
 	options->update_hostkeys = -1;
 	options->hostbased_key_types = NULL;
 	options->pubkey_key_types = NULL;
+#ifdef MPTCP_GET_SUB_IDS
+	options->mptcp_switch_want_mptcp = -1;
+	options->mptcp_switch_nBytes = -1;
+	options->mptcp_switch_time = -1;
+#endif
 }
 
 /*
@@ -2069,6 +2074,14 @@ fill_default_options(Options * options)
 	/* options->hostname will be set in the main program if appropriate */
 	/* options->host_key_alias should not be set by default */
 	/* options->preferred_authentications will be set in ssh */
+#ifdef MPTCP_GET_SUB_IDS
+	if(options->mptcp_switch_want_mptcp == -1)
+		options->mptcp_switch_want_mptcp = 1;
+	if(options->mptcp_switch_nBytes == -1)
+		options->mptcp_switch_nBytes = 500;
+	if(options->mptcp_switch_time == -1)
+		options->mptcp_switch_time == 15;
+#endif
 }
 
 struct fwdarg {

--- a/readconf.h
+++ b/readconf.h
@@ -1,4 +1,4 @@
-/* $oPENbSD: readconf.h,v 1.117 2016/07/15 00:24:30 djm Exp $ */
+/* $OPENbSD: readconf.h,v 1.117 2016/07/15 00:24:30 djm Exp $ */
 
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
@@ -169,12 +169,6 @@ typedef struct {
 	char   *jump_extra;
 
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
-
-#ifdef MPTCP_GET_SUB_IDS
-	int mptcp_switch_want_mptcp;
-	int mptcp_switch_nBytes;
-	int mptcp_switch_time;
-#endif
 
 }       Options;
 

--- a/readconf.h
+++ b/readconf.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: readconf.h,v 1.117 2016/07/15 00:24:30 djm Exp $ */
+/* $oPENbSD: readconf.h,v 1.117 2016/07/15 00:24:30 djm Exp $ */
 
 /*
  * Author: Tatu Ylonen <ylo@cs.hut.fi>
@@ -169,6 +169,13 @@ typedef struct {
 	char   *jump_extra;
 
 	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
+
+#ifdef MPTCP_GET_SUB_IDS
+	int mptcp_switch_want_mptcp;
+	int mptcp_switch_nBytes;
+	int mptcp_switch_time;
+#endif
+
 }       Options;
 
 #define SSH_CANONICALISE_NO	0

--- a/ssh.c
+++ b/ssh.c
@@ -605,7 +605,7 @@ main(int ac, char **av)
 
  again:
 	while ((opt = getopt(ac, av, "1246ab:c:e:fgi:kl:m:no:p:qstvx"
-	    "ACD:E:F:GI:J:KL:MNO:PQ:R:S:TVw:W:XYy")) != -1) {
+	    "ACD:E:F:GI:J:KL:MNO:PQ:R:S:TVw:W:XYyB:")) != -1) {
 		switch (opt) {
 		case '1':
 			options.protocol = SSH_PROTO_1;
@@ -930,8 +930,18 @@ main(int ac, char **av)
 		case 'F':
 			config = optarg;
 			break;
+		case 'B':
+#ifdef MPTCP_GET_SUB_IDS
+			if(strtoi(optarg) > 0)
+				options.mptcp_switch_nBytes = strtoi(optarg);
+			else
+				fatal("Bad argument for B ( <= 0 )");
+#else
+			debug("No support for MPTCP. Options ignored");
+#endif
 		default:
-			usage();
+			if(*optarg != '-')
+				usage();
 		}
 	}
 
@@ -955,34 +965,7 @@ main(int ac, char **av)
 		}
 		ac--, av++;
 	}
-#ifdef MPCTP_GET_SUB_IDS
-	struct option longopt = {
-		{"mptcp=false",no_argument,&options.want_mptcp,0},
-		{"nbytes",optional_argument,&options.mptc_switch_nBytes,500},
-		{"time_subflow",optional_argument,&options.mptcp_switch_time,20},
-		{0,0,0,0}
-	};
 
-	while((c = getopt_long(ac,av,NULL,longopt,NULL)) != -1) {
-		switch(c) {
-		case 0:
-			break;
-		case '?':
-			debug("Bad option parsed. Ignored");
-			break;
-		}
-	}
-
-	if(options.nBytes_change <= 0) {
-		debug("Bad argument for nbytes (<= 0). Using default value (500)");
-		options.mptcp_switch_nBytes = 500;
-	}
-	
-	if(options.timeout_sublfow <= 0) {
-		debug("Bad argument for time_subflow. Using default value (20)");
-		options.mptcp_switch_time = 20;
-	}
-#endif
 	/* Check that we got a host name. */
 	if (!host)
 		usage();

--- a/ssh.c
+++ b/ssh.c
@@ -955,7 +955,34 @@ main(int ac, char **av)
 		}
 		ac--, av++;
 	}
+#ifdef MPCTP_GET_SUB_IDS
+	struct option longopt = {
+		{"mptcp=false",no_argument,&options.want_mptcp,0},
+		{"nbytes",optional_argument,&options.mptc_switch_nBytes,500},
+		{"time_subflow",optional_argument,&options.mptcp_switch_time,20},
+		{0,0,0,0}
+	};
 
+	while((c = getopt_long(ac,av,NULL,longopt,NULL)) != -1) {
+		switch(c) {
+		case 0:
+			break;
+		case '?':
+			debug("Bad option parsed. Ignored");
+			break;
+		}
+	}
+
+	if(options.nBytes_change <= 0) {
+		debug("Bad argument for nbytes (<= 0). Using default value (500)");
+		options.mptcp_switch_nBytes = 500;
+	}
+	
+	if(options.timeout_sublfow <= 0) {
+		debug("Bad argument for time_subflow. Using default value (20)");
+		options.mptcp_switch_time = 20;
+	}
+#endif
 	/* Check that we got a host name. */
 	if (!host)
 		usage();

--- a/ssh.c
+++ b/ssh.c
@@ -946,8 +946,7 @@ main(int ac, char **av)
 			break;
 #endif
 		default:
-			if(*optarg != '-')
-				usage();
+			usage();
 		}
 	}
 


### PR DESCRIPTION
Option B: for user
==============

In this pull request, I put the foundation for further option (as we only have 1 heuristic supported at the moment).  It was hard to change the internal configuration of the OpenSSH code to add what I wanted. So I decided to add a personalize structure (always easier to juste add a pointer than several variables).

In the file packet.h I defined  ``` struct mptcp_heuristics``` to store all variable we need to defines all the heuristics (i.e. all variables we get by the arguments of the program). 

The `struct ssh` in which the ssh connection is "store" now contain a pointer to a `struct mptcp_heuristics` so it's easy to get our heurisitcs.

Add an option
-------------------

To add an option (assuming the associated heuristic is defined and correctly implemented), one should first add all the value needed in the `struct mptcp_heuristics`. Then, one should add the command-line option and getting the value in the ssh.c file. After that we can easily get back the value in packet.c
